### PR TITLE
feat(interval): support partitioning by interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0-alpha.2
 
+### Added
+
+- `partition/2` now also accepts an interval as it's second argument.
+
 ### Fixed
 
 - `adjacent?/2` is now exposed on the interval module via `defdelegate` in the using macro.

--- a/test/continuous_interval_property_test.exs
+++ b/test/continuous_interval_property_test.exs
@@ -136,6 +136,35 @@ defmodule ContinuousIntervalPropertyTest do
     end
   end
 
+  property "partition/2", %{impl: impl} do
+    check all(
+            a <- Helper.interval(impl),
+            b <- Helper.interval(impl)
+          ) do
+      if Interval.contains?(a, b) and not Interval.empty?(b) do
+        [p1, p2, p3] = Interval.partition(a, b)
+        # the middle partition is b (when b is an interval)
+        assert p2 == b
+        # a contains p1,p2,p3 (since we sliced up a in 3 parts)
+        assert Interval.contains?(a, p1)
+        assert Interval.contains?(a, p3)
+        # the union of p1,p2,3 is a
+        a_prime = p1 |> Interval.union(p2) |> Interval.union(p3)
+        assert a_prime == a
+
+        if Interval.unbounded_left?(b) do
+          assert Interval.empty?(p1)
+        end
+
+        if Interval.unbounded_right?(b) do
+          assert Interval.empty?(p3)
+        end
+      else
+        assert [] == Interval.partition(a, b)
+      end
+    end
+  end
+
   property "strictly_left_of?/2 and strictly_right_of?/2 relationship", %{impl: impl} do
     check all(
             a <- Helper.interval(impl, empty: false),

--- a/test/discrete_interval_property_test.exs
+++ b/test/discrete_interval_property_test.exs
@@ -208,4 +208,33 @@ defmodule DiscreteIntervalPropertyTest do
       end
     end
   end
+
+  property "partition/2", %{impl: impl} do
+    check all(
+            a <- Helper.interval(impl),
+            b <- Helper.interval(impl)
+          ) do
+      if Interval.contains?(a, b) and not Interval.empty?(b) do
+        [p1, p2, p3] = Interval.partition(a, b)
+        # the middle partition is b (when b is an interval)
+        assert p2 == b
+        # a contains p1,p2,p3 (since we sliced up a in 3 parts)
+        assert Interval.contains?(a, p1)
+        assert Interval.contains?(a, p3)
+        # the union of p1,p2,3 is a
+        a_prime = p1 |> Interval.union(p2) |> Interval.union(p3)
+        assert a_prime == a
+
+        if Interval.unbounded_left?(b) do
+          assert Interval.empty?(p1)
+        end
+
+        if Interval.unbounded_right?(b) do
+          assert Interval.empty?(p3)
+        end
+      else
+        assert [] == Interval.partition(a, b)
+      end
+    end
+  end
 end

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -489,7 +489,7 @@ defmodule Interval.IntervalTest do
     assert Interval.contains?(floati(1.0, 2.0, "[]"), floati(1.0, 2.0, "()"))
   end
 
-  test "partition/2" do
+  test "partition/2 around a point" do
     assert Interval.partition(inti(1, 4), 2) === [inti(1, 2), inti(2), inti(3)]
     assert Interval.partition(inti(1, 4), 1) === [inti(0, 0), inti(1, 2), inti(2, 4)]
     assert Interval.partition(inti(1, 4), 3) === [inti(1, 3), inti(3), inti(0, 0)]
@@ -507,16 +507,47 @@ defmodule Interval.IntervalTest do
              floati(2.0, 2.0, "[]"),
              floati(2.0, nil, "()")
            ]
+
+    assert Interval.partition(inti(1, 4), 4) === []
+  end
+
+  test "partition/2 around an interval" do
+    a = inti(1, 4)
+    b = inti(2, 2, "[]")
+    assert Interval.partition(a, b) === [inti(1, 2), inti(2, 2, "[]"), inti(3)]
+
+    a = inti(1, 4)
+    b = inti(nil, nil)
+    assert Interval.partition(a, b) === []
+
+    a = inti(nil, 5)
+    b = inti(2, 3, "[]")
+    assert Interval.partition(a, b) === [inti(nil, 2), inti(2, 3, "[]"), inti(3, 5, "()")]
+
+    a = inti(1, nil)
+    b = inti(2, 3, "[]")
+    assert Interval.partition(a, b) === [inti(1, 2, "[)"), inti(2, 3, "[]"), inti(3, nil, "()")]
+
+    a = inti(nil, nil)
+    b = inti(1, 2)
+    assert Interval.partition(a, b) === [inti(nil, 1), inti(1, 2), inti(2, nil)]
+
+    a = inti(nil, nil)
+    b = inti(nil, nil)
+    assert Interval.partition(a, b) === [inti(:empty), inti(nil, nil), inti(:empty)]
+
+    a = inti(nil, nil)
+    b = inti(nil, 2)
+    assert Interval.partition(a, b) === [inti(:empty), inti(nil, 2), inti(2, nil)]
+
+    a = inti(nil, nil)
+    b = inti(2, nil)
+    assert Interval.partition(a, b) === [inti(nil, 2), inti(2, nil), inti(:empty)]
   end
 
   test "partition/2's result unioned together is it's input interval" do
     a = inti(1, 4)
-
-    b =
-      a
-      |> Interval.partition(2)
-      |> Enum.reduce(&Interval.union/2)
-
+    b = a |> Interval.partition(2) |> Enum.reduce(&Interval.union/2)
     assert a === b
   end
 

--- a/test/regression_test.exs
+++ b/test/regression_test.exs
@@ -50,4 +50,23 @@ defmodule Interval.RegressionTest do
              right: {:exclusive, Decimal.new("1")}
            }
   end
+
+  test "partition/2 regression 2025-03-11" do
+    a = %IntegerInterval{left: {:inclusive, 2}, right: :unbounded}
+    b = %IntegerInterval{left: {:inclusive, -1}, right: :unbounded}
+    assert [] = Interval.partition(a, b)
+
+    a = %IntegerInterval{left: :unbounded, right: :unbounded}
+    b = %IntegerInterval{left: :unbounded, right: :unbounded}
+
+    assert [
+             %IntegerInterval{left: :empty, right: :empty},
+             %IntegerInterval{left: :unbounded, right: :unbounded},
+             %IntegerInterval{left: :empty, right: :empty}
+           ] = Interval.partition(a, b)
+
+    a = %Interval.IntegerInterval{left: {:inclusive, 1}, right: :unbounded}
+    b = %Interval.IntegerInterval{left: {:inclusive, -2}, right: :unbounded}
+    assert Interval.partition(a, b) == []
+  end
 end


### PR DESCRIPTION
- `partition/2` now accepts an interval as its second argument.
- Added property-based tests for `partition/2`.
- Added regression tests for `partition/2`.